### PR TITLE
Fixed an issue with XmlRepeater priority.

### DIFF
--- a/XmlDecoratorInterface.php
+++ b/XmlDecoratorInterface.php
@@ -11,4 +11,11 @@ interface XmlDecoratorInterface
      * @return string
      */
     public function run($content);
+
+    /**
+     * Returns a boolean value indicating whether the decorator succeeded.
+     *
+     * @return boolean
+     */
+    public function isSuccess();
 }

--- a/XmlRepeater.php
+++ b/XmlRepeater.php
@@ -3,15 +3,24 @@ namespace SymfonyXmlResponse\Responses;
 
 class XmlRepeater implements XmlDecoratorInterface
 {
+    /** @var mixed */
     protected $placeholder;
+
+    /** @var string */
     protected $repeatingElement;
+
+    /** @var array */
     protected $repeatingData;
+
+    /** @var boolean */
+    private $success = false;
 
     /**
      * XmlRepeater constructor.
-     * @param string $placeholder   marker to look for in the content and replace with new (repeating) content
-     * @param string $repeatingElement  name of the XML element that repeats
-     * @param array $repeatingData  indexed array of repeating data
+     *
+     * @param string $placeholder      Marker to look for in the content and replace with new (repeating) content.
+     * @param string $repeatingElement Name of the XML element that repeats.
+     * @param array  $repeatingData    Indexed array of repeating data.
      */
     public function __construct($placeholder, $repeatingElement, array $repeatingData)
     {
@@ -36,6 +45,19 @@ class XmlRepeater implements XmlDecoratorInterface
             $xml[] = $xr->getFragment($this->repeatingElement, $item);
         }
 
-        return str_replace($this->placeholder, implode("\n", $xml), $content);
+        $replacements = 0;
+        $content = str_replace($this->placeholder, implode("\n", $xml), $content, $replacements);
+
+        $this->success = $replacements > 0;
+
+        return $content;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isSuccess()
+    {
+        return $this->success;
     }
 }

--- a/XmlResponse.php
+++ b/XmlResponse.php
@@ -38,7 +38,7 @@ class XmlResponse extends Response
     /**
      * Array of objects that implement the XmlDecoratorInterface, each of which
      * will be run as the content is rendered.
-     * @var array
+     * @var XmlDecoratorInterface[]
      */
     protected $decorators = array();
 
@@ -249,8 +249,15 @@ class XmlResponse extends Response
      */
     public function sendContent()
     {
-        foreach ($this->decorators as $decor) {
+        while (list($key, $decor) = each($this->decorators)) {
+            /** @var $decor XmlDecoratorInterface */
             $this->content = $decor->run($this->content);
+
+            if ($decor->isSuccess()) {
+                unset($this->decorators[$key]);
+                reset($this->decorators);
+            }
+
         }
 
         return parent::sendContent();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+
+use SymfonyXmlResponse\Responses\XmlRepeater;
+use SymfonyXmlResponse\Responses\XmlResponse;
+
+class IntegrationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that even when decorators are added in incorrect order the replacement still occurs
+     *
+     * @return void
+     */
+    public function testRepeaterPriority()
+    {
+        // Arrange
+        $response = new XmlResponse();
+        $data = [
+            'someContent' => [
+                '@replaceThis@'
+            ]
+        ];
+
+        $nestedReplace = [
+            '@nestedReplace@'
+        ];
+
+        $r1 = new XmlRepeater('@replaceThis@', 'replacedEl', $nestedReplace);
+        $r2 = new XmlRepeater('@nestedReplace@', 'nestedEl', ['stuff', 'more stuff']);
+        $response->addDecorator($r2);
+        $response->addDecorator($r1);
+
+        //Act
+        $response->setData($data);
+        ob_start();
+        $response->sendContent();
+        $output = ob_get_clean();
+
+        //Assert
+        $this->assertEquals($this->getExpectedXml(), $output);
+    }
+
+    private function getExpectedXml()
+    {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" .
+               "<document>\n" .
+               " <someContent><replacedEl><nestedEl>stuff</nestedEl>\n" .
+               "\n" .
+               "<nestedEl>more stuff</nestedEl>\n" .
+               "</replacedEl>\n" .
+               "</someContent>\n" .
+               "</document>\n";
+    }
+}

--- a/tests/XmlDecoratorTest.php
+++ b/tests/XmlDecoratorTest.php
@@ -48,7 +48,10 @@ class XmlDecoratorTest extends \PHPUnit_Framework_TestCase
         $xr->addDecorator($dec1);
         $xr->addDecorator($dec2);
         $xr->addDecorator($dec3);
+
+        ob_start();
         $response = $xr->sendContent();
+        ob_end_clean();
 
         $this->assertEquals('stuff3', $response->getContent());
     }

--- a/tests/XmlDecoratorTest.php
+++ b/tests/XmlDecoratorTest.php
@@ -7,7 +7,6 @@
  */
 
 use SymfonyXmlResponse\Responses\XmlResponse;
-use SymfonyXmlResponse\Responses\XmlDecoratorInterface;
 
 class XmlDecoratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,10 +36,13 @@ class XmlDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $dec1 = Mockery::mock('SymfonyXmlResponse\Responses\XmlDecoratorInterface');
         $dec1->shouldReceive('run')->once()->andReturn('stuff1');
+        $dec1->shouldReceive('isSuccess')->andReturn(true);
         $dec2 = Mockery::mock('SymfonyXmlResponse\Responses\XmlDecoratorInterface');
         $dec2->shouldReceive('run')->once()->andReturn('stuff2');
+        $dec2->shouldReceive('isSuccess')->andReturn(true);
         $dec3 = Mockery::mock('SymfonyXmlResponse\Responses\XmlDecoratorInterface');
         $dec3->shouldReceive('run')->once()->andReturn('stuff3');
+        $dec3->shouldReceive('isSuccess')->andReturn(true);
 
         $xr = new XmlResponse();
         $xr->addDecorator($dec1);


### PR DESCRIPTION
There's an issue with `sendContent` and `run` methods.
`run` method will traverse the array of decorators and apply each of them regardless of whether there's something to decorate at the moment within `content`. 
If you have multiple decorators that depend one on another and one must be called after another then priority matters. In the current implementation some replacements will simply be ignored if there's nothing to replace at the moment.
This PR aims to fix that by adding a verification whether a replacement has been made and if so - reset the array and iterate through it again.
